### PR TITLE
Optional functionality to calculate percentiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ Here is an example of running the app:
     --args="--nuclear-mask=$PWD/app/src/test/resources/synthetic_test_nuclear.tiff \
             --whole-cell-mask=$PWD/app/src/test/resources/synthetic_test_whole-cell.tiff \
             --tiff-file=$PWD/app/src/test/resources/synthetic_test.ome.tif \
-            --output-file=$PWD/segmentation.geojson"
+            --output-file=$PWD/segmentation.geojson \
+            --skip-measurements=false \
+            --percentiles=70,80,90,95,96,97,98,99"
 ```
 
 Make sure to use absolute paths.
@@ -54,16 +56,19 @@ Full arguments:
 
 ```
 Usage: cellmeasurement [-hV] [--skip-measurements] [-d=<downsampleFactor>]
-                       [-e=<cellExpansion>] [-i=<distThreshold>]
-                       -n=<nuclearMaskFilePath> -o=<outputFilePath>
-                       [-p=<pixelSizeMicrons>] -t=<tiffFilePath>
+                       [-e=<estimateCellBoundaryDist>] -f=<tiffFilePath>
+                       [-i=<distThreshold>] -n=<nuclearMaskFilePath>
+                       -o=<outputFilePath> [-p=<pixelSizeMicrons>]
+                       [--percentiles=<percentiles>] [-t=<threads>]
                        -w=<wholeCellMaskFilePath>
 Extract cell measurements from nuclear and whole-cell segmentation masks.
   -d, --downsample-factor=<downsampleFactor>
                             Downsample factor
-  -e, --cell-expansion=<cellExpansion>
-                            Expansion factor for cell boundary estimation in
-                              pixels (default = 3.0)
+  -e, --estimate-cell-boundary-dist=<estimateCellBoundaryDist>
+                            Where no matching membrane ROI exists, expand the
+                              nucleus by this many pixels (default = 3.0)
+  -f, --tiff-file=<tiffFilePath>
+                            TIFF file containing multi-channel image data
   -h, --help                Show this help message and exit.
   -i, --dist-threshold=<distThreshold>
                             Distance threshold (in pixels) for matching ROIs
@@ -73,9 +78,13 @@ Extract cell measurements from nuclear and whole-cell segmentation masks.
                             Output path for GeoJSON file
   -p, --pixel-size-microns=<pixelSizeMicrons>
                             Pixel size in microns (default: 0.5)
+      --percentiles=<percentiles>
+                            Calculate specified comma-separated intensity
+                              percentiles. Only works if not skipping
+                              measurements. E.g. "70,80,90,95,96,97,98,99"
       --skip-measurements   Skip adding measurements
-  -t, --tiff-file=<tiffFilePath>
-                            TIFF file containing multi-channel image data
+  -t, --threads=<threads>   Number of threads to use for parallel processing
+                              (default: 1)
   -V, --version             Print version information and exit.
   -w, --whole-cell-mask=<wholeCellMaskFilePath>
                             Whole-cell segmentation mask file in TIFF format

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,6 +40,9 @@ dependencies {
     // ImageJ dependency
     implementation libs.imagej
 
+    // Apache Commons Math dependency
+    implementation libs.commons.math
+
     // QuPath dependencies
     implementation 'io.github.qupath:qupath-core:0.5.1'
     implementation 'io.github.qupath:qupath-core-processing:0.5.1'

--- a/app/src/main/groovy/wehisodahub/cellmeasurement/App.groovy
+++ b/app/src/main/groovy/wehisodahub/cellmeasurement/App.groovy
@@ -84,9 +84,9 @@ class App implements Runnable {
     boolean skipMeasurements = false
 
     @Option(names = ['--percentiles'],
-            description = 'Calculate intensity percentiles. Only works if not skipping measurements.',
+            description = 'Calculate specified comma-separated intensity percentiles. Only works if not skipping measurements. E.g. "70,80,90,95,96,97,98,99"',
             required = false)
-    boolean percentiles = false
+    String percentiles = ''
 
     @Option(names = ['-i', '--dist-threshold'],
             description = 'Distance threshold (in pixels) for matching ROIs',
@@ -482,14 +482,16 @@ class App implements Runnable {
                 }
             }
 
-            if (percentiles) {
+            if (percentiles != '') {
                 println 'Adding intensity percentiles...'
+                def percentileList = percentiles.split(',').collect { it as Double }
                 GParsPool.withPool(threads) {
                     pathObjects.eachParallel { pathObject ->
                         addPercentileMeasurements(
                             server,
                             pathObject,
-                            downsampleFactor
+                            downsampleFactor,
+                            percentileList
                         )
                     }
                 }

--- a/app/src/main/groovy/wehisodahub/cellmeasurement/App.groovy
+++ b/app/src/main/groovy/wehisodahub/cellmeasurement/App.groovy
@@ -8,13 +8,20 @@ import groovyx.gpars.GParsPool
 
 import java.awt.geom.Point2D
 import java.nio.file.Paths
+import java.awt.Rectangle
+import java.awt.image.BufferedImage
+
+import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics
 
 import ij.IJ
 import ij.process.ColorProcessor
+import ij.process.ByteProcessor
+import ij.process.ImageProcessor
 
 import qupath.imagej.processing.RoiLabeling
 import qupath.imagej.tools.IJTools
 
+import qupath.lib.roi.RectangleROI
 import qupath.lib.roi.interfaces.ROI
 import qupath.lib.roi.ROIs
 import qupath.lib.roi.GeometryTools
@@ -23,8 +30,10 @@ import qupath.lib.objects.PathObject
 import qupath.lib.objects.PathObjects
 import qupath.lib.objects.CellTools
 import qupath.lib.regions.ImagePlane
+import qupath.lib.regions.RegionRequest
 import qupath.lib.io.PathIO.GeoJsonExportOptions
 import qupath.lib.analysis.features.ObjectMeasurements
+import qupath.lib.measurements.MeasurementList
 import qupath.lib.images.servers.PixelCalibration
 import qupath.lib.images.servers.bioformats.BioFormatsServerBuilder
 
@@ -73,6 +82,11 @@ class App implements Runnable {
             description = 'Skip adding measurements',
             required = false)
     boolean skipMeasurements = false
+
+    @Option(names = ['--percentiles'],
+            description = 'Calculate intensity percentiles. Only works if not skipping measurements.',
+            required = false)
+    boolean percentiles = false
 
     @Option(names = ['-i', '--dist-threshold'],
             description = 'Distance threshold (in pixels) for matching ROIs',
@@ -186,6 +200,199 @@ class App implements Runnable {
         }
     }
 
+    /**
+     * Add percentile measurements for cell objects by compartment
+     * @param server ImageServer containing the pixel data
+     * @param pathObject PathObject to measure (MeasurementList will be updated)
+     * @param downsampleFactor Resolution at which to request pixels
+     * @param percentiles List of percentiles to calculate (default: [70, 80, 90, 95, 96, 97, 98, 99])
+     * @param compartments Set of compartments to measure ('NUCLEUS', 'CYTOPLASM', 'MEMBRANE', 'CELL')
+     */
+    def addPercentileMeasurements(server, PathObject pathObject, double downsampleFactor = 1.0,
+                                  List<Double> percentiles = [70, 80, 90, 95, 96, 97, 98, 99],
+                                  Set<String> compartments = ['NUCLEUS', 'CYTOPLASM', 'MEMBRANE', 'CELL']) {
+
+        // Only process cells
+        if (!pathObject.isCell()) {
+            return
+        }
+
+        def cell = pathObject
+        def cellROI = cell.getROI()
+        def nucleusROI = cell.getNucleusROI()
+
+        if (cellROI == null) {
+            return
+        }
+
+        // Get bounding box for the cell
+        def bounds = cellROI.getBoundsX() != Double.POSITIVE_INFINITY ?
+                     new RectangleROI((cellROI.getBoundsX() / downsampleFactor),
+                                      (cellROI.getBoundsY() / downsampleFactor),
+                                      (cellROI.getBoundsWidth() / downsampleFactor + 1),
+                                      (cellROI.getBoundsHeight() / downsampleFactor + 1)) :
+                     new RectangleROI(0, 0, server.getWidth(), server.getHeight())
+
+        // Create region request
+        def request = RegionRequest.createInstance(server.getPath(), downsampleFactor, bounds)
+
+        try {
+            // Get the image data
+            def img = server.readRegion(request)
+            if (img == null) return
+
+            int width = img.getWidth()
+            int height = img.getHeight()
+            int nChannels = server.nChannels()
+
+            // Create compartment masks
+            def pathImage = IJTools.convertToImagePlus(server, request);
+            def masks = createCompartmentMasks(cellROI, nucleusROI, width, height, pathImage, compartments)
+
+            // Extract pixel values for each channel and compartment
+            def measurements = cell.getMeasurementList()
+
+            for (int c = 0; c < nChannels; c++) {
+                def channelName = server.getChannel(c).getName()
+                def pixelValues = extractChannelPixels(img, c, width, height)
+
+                masks.each { compartment, mask ->
+                    if (compartments.contains(compartment)) {
+                        def compartmentPixels = getCompartmentPixels(pixelValues, mask)
+                        if (compartmentPixels.size() > 0) {
+                            addPercentileMeasurementsForCompartment(measurements, compartmentPixels,
+                                                                    channelName, compartment, percentiles)
+                        }
+                    }
+                }
+            }
+
+        } catch (Exception e) {
+            println("Error processing ${pathObject}: ${e.getMessage()}")
+        }
+    }
+
+    /**
+     * Create binary masks for different cell compartments
+     */
+    def createCompartmentMasks(cellROI, nucleusROI, int width, int height, pathImage, compartments) {
+        def masks = [:]
+
+        // Create cell mask
+        if (compartments.contains('CELL')) {
+            masks['CELL'] = createROIMask(cellROI, width, height, pathImage)
+        }
+
+        // Create nucleus mask
+        def nucleusMask = null
+        if (nucleusROI != null && (compartments.contains('NUCLEUS') || compartments.contains('CYTOPLASM'))) {
+            nucleusMask = createROIMask(nucleusROI, width, height, pathImage)
+            if (compartments.contains('NUCLEUS')) {
+                masks['NUCLEUS'] = nucleusMask
+            }
+        }
+
+        // Create cytoplasm mask (cell - nucleus)
+        if (compartments.contains('CYTOPLASM') && masks.containsKey('CELL') && nucleusMask != null) {
+            masks['CYTOPLASM'] = subtractMasks(masks['CELL'], nucleusMask)
+        }
+
+        // Create membrane mask (cell boundary)
+        if (compartments.contains('MEMBRANE') && masks.containsKey('CELL')) {
+            masks['MEMBRANE'] = createMembraneMask(masks['CELL'])
+        }
+
+        return masks
+    }
+
+    /**
+     * Create binary mask from ROI
+     */
+    def createROIMask(roi, int width, int height, pathImage) {
+        def mask = new ByteProcessor(width, height)
+
+        def roiIJ = IJTools.convertToIJRoi(roi, pathImage)
+
+        mask.setColor(255)
+        mask.fill(roiIJ)
+
+        return mask
+    }
+
+    /**
+     * Subtract one mask from another
+     */
+    def subtractMasks(mask1, mask2) {
+        def result = mask1.duplicate()
+        def pixels1 = result.getPixels() as byte[]
+        def pixels2 = mask2.getPixels() as byte[]
+
+        for (int i = 0; i < pixels1.length; i++) {
+            if (pixels2[i] != 0) {
+                pixels1[i] = 0
+            }
+        }
+
+        return result
+    }
+
+    /**
+     * Create membrane mask by finding boundary pixels
+     */
+    def createMembraneMask(cellMask) {
+        def membrane = cellMask.duplicate()
+        membrane.findEdges()
+        return membrane
+    }
+
+    /**
+     * Extract pixel values for a specific channel
+     */
+    def extractChannelPixels(BufferedImage img, int channel, int width, int height) {
+        def pixels = new float[width * height]
+        def raster = img.getRaster()
+
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                pixels[y * width + x] = raster.getSampleFloat(x, y, channel)
+            }
+        }
+
+        return pixels
+    }
+
+    /**
+     * Get pixel values within a compartment mask
+     */
+    def getCompartmentPixels(float[] allPixels, ByteProcessor mask) {
+        def maskPixels = mask.getPixels() as byte[]
+        def compartmentPixels = []
+
+        for (int i = 0; i < maskPixels.length; i++) {
+            if (maskPixels[i] != 0) {
+                compartmentPixels.add(allPixels[i] as double)
+            }
+        }
+
+        return compartmentPixels
+    }
+
+    /**
+     * Calculate and add percentile measurements for a compartment
+     */
+    def addPercentileMeasurementsForCompartment(MeasurementList measurements, List<Double> pixels,
+                                               String channelName, String compartment, List<Double> percentiles) {
+        def stats = new DescriptiveStatistics()
+        pixels.each { stats.addValue(it) }
+
+        percentiles.each { percentile ->
+            def value = stats.getPercentile(percentile)
+            def capitalisedCompartment = compartment.toLowerCase().capitalize()
+            def measurementName = "${channelName}: ${capitalisedCompartment}: Percentile: ${percentile}"
+            measurements.putMeasurement(measurementName, value)
+        }
+    }
+
     @Override
     void run() {
         // Load whole cell mask image
@@ -272,6 +479,19 @@ class App implements Runnable {
                         measurements,
                         compartments
                     )
+                }
+            }
+
+            if (percentiles) {
+                println 'Adding intensity percentiles...'
+                GParsPool.withPool(threads) {
+                    pathObjects.eachParallel { pathObject ->
+                        addPercentileMeasurements(
+                            server,
+                            pathObject,
+                            downsampleFactor
+                        )
+                    }
                 }
             }
         }

--- a/app/src/test/groovy/wehisodahub/cellmeasurement/AppTest.groovy
+++ b/app/src/test/groovy/wehisodahub/cellmeasurement/AppTest.groovy
@@ -4,21 +4,29 @@ import spock.lang.Specification
 import spock.lang.TempDir
 import spock.lang.Shared
 import spock.lang.Subject
+import spock.lang.Unroll
 
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.nio.file.Files
 import java.awt.geom.Point2D
+import java.net.URI
 
 import ij.ImagePlus
 import ij.process.ByteProcessor
+
+import qupath.imagej.tools.IJTools
 
 import qupath.lib.roi.interfaces.ROI
 import qupath.lib.roi.ROIs
 import qupath.lib.objects.PathObject
 import qupath.lib.objects.PathObjects
 import qupath.lib.regions.ImagePlane
-
+import qupath.lib.regions.RegionRequest
+import qupath.lib.images.PathImage
+import qupath.lib.images.servers.ImageServer
+import qupath.lib.images.servers.bioformats.BioFormatsServerBuilder
+import qupath.lib.measurements.MeasurementList
 
 class AppSpec extends Specification {
 
@@ -161,6 +169,132 @@ class AppSpec extends Specification {
         result[0].size() == 2
         result[0][0] == nuclearROI
     }
+ 
+    def "addPercentileMeasurements should return early when pathObject is not a cell"() {
+        given:
+        def server = createMockImageServer(100, 100)
+        def pathObject = createMockPathObject(10, 10, 20, 20)
+        pathObject.isCell() >> false
+
+        when:
+        app.addPercentileMeasurements(server, pathObject)
+
+        then:
+        0 * _
+    }
+
+    def "addPercentileMeasurements should return early when cellROI is null"() {
+        given:
+        def server = createMockImageServer(100, 100)
+        def pathObject = createMockPathObject(10, 10, 20, 20)
+        pathObject.isCell() >> true
+        pathObject.getROI() >> null
+
+        when:
+        app.addPercentileMeasurements(server, pathObject)
+
+        then:
+        0 * server._
+    }
+
+    @Unroll
+    def "addPercentileMeasurements should process cell with #compartments compartments"() {
+        given:
+        def server = createMockImageServer(100, 100)
+        def pathObject = createMockPathObject(10, 10, 50, 50)
+        pathObject.isCell() >> true
+        
+        when:
+        app.addPercentileMeasurements(server, pathObject, 1.0, [95.0], compartments as Set)
+
+        then:
+        noExceptionThrown()
+
+        where:
+        compartments << [['CELL'], ['NUCLEUS'], ['CYTOPLASM'], ['MEMBRANE']]
+    }
+
+    def "createCompartmentMasks should create only requested compartment masks"() {
+        given:
+        def cellROI = ROIs.createRectangleROI(0, 0, 50, 50, ImagePlane.getDefaultPlane())
+        def nucleusROI = ROIs.createRectangleROI(10, 10, 20, 20, ImagePlane.getDefaultPlane())
+        def tiffFilePath = getClass().getResource('/synthetic_test.ome.tif').toURI()
+        def pathImage = getPathImage(tiffFilePath)
+        def compartments = ['CELL', 'NUCLEUS'] as Set
+
+        when:
+        def masks = app.createCompartmentMasks(cellROI, nucleusROI, 100, 100, pathImage, compartments)
+
+        then:
+        masks.keySet() == ['CELL', 'NUCLEUS'] as Set
+        masks['CELL'] instanceof ByteProcessor
+        masks['NUCLEUS'] instanceof ByteProcessor
+    }
+
+    def "createCompartmentMasks should create cytoplasm mask when both cell and nucleus are requested"() {
+        given:
+        def cellROI = ROIs.createRectangleROI(0, 0, 50, 50, ImagePlane.getDefaultPlane())
+        def nucleusROI = ROIs.createRectangleROI(10, 10, 20, 20, ImagePlane.getDefaultPlane())
+        def tiffFilePath = getClass().getResource('/synthetic_test.ome.tif').toURI()
+        def pathImage = getPathImage(tiffFilePath)
+        def compartments = ['CELL', 'NUCLEUS', 'CYTOPLASM'] as Set
+
+        when:
+        def masks = app.createCompartmentMasks(cellROI, nucleusROI, 100, 100, pathImage, compartments)
+
+        then:
+        masks.keySet().containsAll(['CELL', 'NUCLEUS', 'CYTOPLASM'])
+        masks['CYTOPLASM'] instanceof ByteProcessor
+    }
+
+    def "createROIMask should create ByteProcessor with correct dimensions"() {
+        given:
+        def roi = ROIs.createRectangleROI(10, 10, 20, 20, ImagePlane.getDefaultPlane())
+        def tiffFilePath = getClass().getResource('/synthetic_test.ome.tif').toURI()
+        def pathImage = getPathImage(tiffFilePath)
+
+        when:
+        def mask = app.createROIMask(roi, 50, 30, pathImage)
+
+        then:
+        mask instanceof ByteProcessor
+        mask.getWidth() == 50
+        mask.getHeight() == 30
+    }
+
+    def "getCompartmentPixels should extract only masked pixels"() {
+        given:
+        def allPixels = [10.0f, 20.0f, 30.0f, 40.0f] as float[]
+        def mask = new ByteProcessor(2, 2)
+        mask.set(0, 0, 255)  // Include first pixel
+        mask.set(1, 1, 255)  // Include fourth pixel
+
+        when:
+        def compartmentPixels = app.getCompartmentPixels(allPixels, mask)
+
+        then:
+        compartmentPixels.size() == 2
+        compartmentPixels.contains(10.0d)
+        compartmentPixels.contains(40.0d)
+    }
+
+    @Unroll
+    def "addPercentileMeasurementsForCompartment should add measurements for percentiles #percentiles"() {
+        given:
+        def measurements = Mock(MeasurementList)
+        def pixels = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+        def channelName = "TestChannel"
+        def compartment = "NUCLEUS"
+
+        when:
+        app.addPercentileMeasurementsForCompartment(measurements, pixels, channelName, compartment, percentiles)
+
+        then:
+        percentiles.size() * measurements.putMeasurement(_, _)
+
+        where:
+        percentiles << [[50.0], [70.0, 90.0], [95.0, 99.0]]
+    }
 
     def "should process real image files"() {
         given:
@@ -169,6 +303,7 @@ class AppSpec extends Specification {
         app.skipMeasurements = false
         app.distThreshold = 10.0
         app.estimateCellBoundaryDist = 3.0
+        app.percentiles = '90,95'
         app.threads = 1
 
         def nuclearMaskPath = getClass().getResource('/synthetic_test_nuclear.tiff').toURI()
@@ -211,5 +346,24 @@ class AppSpec extends Specification {
         def pathObject =  PathObjects.createDetectionObject(roi)
         pathObject.getROI() >> roi
         return pathObject
+    }
+
+    private ImageServer createMockImageServer(int width, int height) {
+        def server = Mock(ImageServer)
+        server.getWidth() >> width
+        server.getHeight() >> height
+        return server
+    }
+
+    private PathImage getPathImage(URI imageUri) {
+        def builder = new BioFormatsServerBuilder()
+        def server = builder.buildServer(imageUri)
+        
+        def request = RegionRequest.createInstance(
+            server.getPath(),
+            1.0, 0, 0, server.getWidth(), server.getHeight()
+        )
+
+        return IJTools.convertToImagePlus(server, request);
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ guava = "33.3.1-jre"
 imagej = "1.54p"
 picocli = "4.7.6"
 gpars = "1.2.1"
+commons-math = "3.6.1"
 
 [libraries]
 groovy-all = { module = "org.codehaus.groovy:groovy-all", version.ref = "groovy-all" }
@@ -14,3 +15,4 @@ guava = { module = "com.google.guava:guava", version.ref = "guava" }
 imagej = { module = "net.imagej:ij", version.ref = "imagej" }
 picocli = { module = "info.picocli:picocli", version.ref = "picocli" }
 gpars = { module = "org.codehaus.gpars:gpars", version.ref = "gpars" }
+commons-math = { module = "org.apache.commons:commons-math3", version.ref = "commons-math" }


### PR DESCRIPTION
Can specify a percentile list, e.g., `--percentiles=70,80,90,95,96,97,98,99`, in which case intensity percentiles per channel and compartment will be added to the measurements list (incompatible with `--skip-measurements=true`).

The QuPath API does not allow us to return the measurements list for a given compartment, so this implementation is re-implementing a lot of what QuPath is doing internally to calculate measurements, but I do not see a way around this.

I made sure to use `org.apache.commons.math3.stat.descriptive.DescriptiveStatistics` to calculate the stats as this is what QuPath uses internally. From testing median values (percentile = 50), we are getting a match in values to what QuPath calculates.