### PR TITLE
Use Bio-Formats for loading mask images

### DIFF
--- a/app/src/main/groovy/wehisodahub/cellmeasurement/App.groovy
+++ b/app/src/main/groovy/wehisodahub/cellmeasurement/App.groovy
@@ -13,8 +13,6 @@ import java.awt.image.BufferedImage
 
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics
 
-import ij.IJ
-import ij.ImagePlus
 import ij.process.ColorProcessor
 import ij.process.ByteProcessor
 import ij.process.ImageProcessor
@@ -517,7 +515,7 @@ class App implements Runnable {
     }
 
     /**
-     * Convert a Bio-Formats ImageServer to an ImageJ ImagePlus
+     * Convert a Bio-Formats ImageServer to an ImageJ ImagePlus object to ensure compatibility with ROI conversion and feature generation code
      * @param server ImageServer to convert
      * @return ImagePlus containing the image data
      */
@@ -526,23 +524,29 @@ class App implements Runnable {
         return IJTools.convertToImagePlus(server, request)
     }
 
+    /**
+     * Load a mask image file using Bio-Formats and convert to ImagePlus
+     * @param filePath Path to the mask image file
+     * @return ImagePlus containing the mask image data
+     */
+    static loadMaskAsImagePlus(String filePath) {
+        def uri = Paths.get(filePath).toUri()
+        def builder = new BioFormatsServerBuilder()
+        def server = builder.buildServer(uri)
+        return convertServerToImagePlus(server).getImage()
+    }
+
     @Override
     void run() {
-        // Load whole cell mask using Bio-Formats via QuPath
-        def wholeCellUri = Paths.get(wholeCellMaskFilePath).toUri()
-        def wholeCellBuilder = new BioFormatsServerBuilder()
-        def wholeCellServer = wholeCellBuilder.buildServer(wholeCellUri)
-        def wholeCellImp = convertServerToImagePlus(wholeCellServer).getImage()
+        // Load whole cell mask using Bio-Formats via QuPath, more robust than ImageJ for very large images
+        def wholeCellImp = loadMaskAsImagePlus(wholeCellMaskFilePath)
         println 'Loaded whole cell mask width: ' + wholeCellImp.getWidth()
 
-        // Load nuclear mask using Bio-Formats via QuPath
-        def nuclearUri = Paths.get(nuclearMaskFilePath).toUri()
-        def nuclearBuilder = new BioFormatsServerBuilder()
-        def nuclearServer = nuclearBuilder.buildServer(nuclearUri)
-        def nuclearImp = convertServerToImagePlus(nuclearServer).getImage()
+        // Load nuclear mask using Bio-Formats via QuPath, more robust than ImageJ for very large images
+        def nuclearImp = loadMaskAsImagePlus(nuclearMaskFilePath)
         println 'Loaded nuclear mask width: ' + nuclearImp.getWidth()
 
-        // Build a server with supplied TIFF file
+        // Build a server with supplied TIFF file using bioformats
         def uri = Paths.get(tiffFilePath).toUri()
         def builder = new BioFormatsServerBuilder()
         def server = builder.buildServer(uri)


### PR DESCRIPTION
Closes https://github.com/WEHI-SODA-Hub/cellmeasurement/issues/4

- Replace IJ.openImage() with BioFormatsServerBuilder from QuPath for better handling of large TIFF files
- Add convertServerToImagePlus() helper method to convert ImageServer from bioformats after loading images to ImagePlus to ensure code compatibility 
- Use QuPath's Bio-Formats integration (version 7.0.1) to avoid version conflicts
- All tests passing
- Improves support for large images,
- will need to validate with large image using pipeline